### PR TITLE
Initfile support

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,24 +1,28 @@
 module.exports = (grunt) ->
     grunt.initConfig
         coffeeCoverage:
-            all: src: "tasks", dest: "tasks-cov"
+            options:
+                initFile: 'tasks-cov/init.js'
+            all:
+                src: 'tasks'
+                dest: 'tasks-cov'
         coffeelint:
             options: indentation: value: 4
-            all: src: "tasks/*.coffee"
+            all: src: 'tasks/*.coffee'
         simplemocha:
-            options: reporter: "spec"
-            all: src: "test/*.coffee"
-        clean: 
-            all: "tasks-cov"
+            options: reporter: 'spec'
+            all: src: 'test/*.coffee'
+        clean:
+            all: 'tasks-cov'
 
-    grunt.loadTasks "tasks"
-    grunt.loadNpmTasks "grunt-coffeelint"
-    grunt.loadNpmTasks "grunt-simple-mocha"
-    grunt.loadNpmTasks "grunt-contrib-clean"
-    grunt.registerTask "default", [
-        "clean",
-        "coffeeCoverage",
-        "simplemocha",
-        "coffeelint",
-        "clean"
+    grunt.loadTasks 'tasks'
+    grunt.loadNpmTasks 'grunt-coffeelint'
+    grunt.loadNpmTasks 'grunt-simple-mocha'
+    grunt.loadNpmTasks 'grunt-contrib-clean'
+    grunt.registerTask 'default', [
+        'clean',
+        'coffeeCoverage',
+        'simplemocha',
+        'coffeelint',
+        'clean'
     ]

--- a/package.json
+++ b/package.json
@@ -5,12 +5,8 @@
     "gruntplugin",
     "coffee-coverage"
   ],
-  "version": "0.1.1",
-  "homepage": "https://github.com/rithis/grunt-coffee-coverage",
-  "bugs": {
-    "url": "https://github.com/rithis/grunt-coffee-coverage/issues",
-    "email": "webmaster@rithis.com"
-  },
+  "version": "0.1.2",
+  "homepage": "https://github.com/FredrikAppelros/grunt-coffee-coverage.git",
   "author": {
     "name": "Vyacheslav Slinko",
     "email": "vyacheslav.slinko@gmail.com"
@@ -18,7 +14,7 @@
   "main": "Gruntfile",
   "repository": {
     "type": "git",
-    "url": "git://github.com/rithis/grunt-coffee-coverage.git"
+    "url": "https://github.com/FredrikAppelros/grunt-coffee-coverage.git"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -1,33 +1,39 @@
 {
-    "name": "grunt-coffee-coverage",
-    "description": "JSCoverage-style instrumentation for CoffeeScript files.",
-    "keywords": ["gruntplugin", "coffee-coverage"],
-    "version": "0.1.1",
-    "homepage": "https://github.com/rithis/grunt-coffee-coverage",
-    "bugs": {
-        "url": "https://github.com/rithis/grunt-coffee-coverage/issues",
-        "email": "webmaster@rithis.com"
-    },
-    "author": {
-        "name": "Vyacheslav Slinko",
-        "email": "vyacheslav.slinko@gmail.com"
-    },
-    "main": "Gruntfile",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/rithis/grunt-coffee-coverage.git"
-    },
-    "scripts": {
-        "test": "grunt test"
-    },
-    "dependencies": {
-        "coffee-coverage": "~0.1",
-        "grunt-coffeelint": "~0.0",
-        "grunt-simple-mocha": "~0.4",
-        "grunt-contrib-clean": "~0.4"
-    },
-    "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.2"
-    }
+  "name": "grunt-coffee-coverage",
+  "description": "JSCoverage-style instrumentation for CoffeeScript files.",
+  "keywords": [
+    "gruntplugin",
+    "coffee-coverage"
+  ],
+  "version": "0.1.1",
+  "homepage": "https://github.com/rithis/grunt-coffee-coverage",
+  "bugs": {
+    "url": "https://github.com/rithis/grunt-coffee-coverage/issues",
+    "email": "webmaster@rithis.com"
+  },
+  "author": {
+    "name": "Vyacheslav Slinko",
+    "email": "vyacheslav.slinko@gmail.com"
+  },
+  "main": "Gruntfile",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rithis/grunt-coffee-coverage.git"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "coffee-coverage": "~0.1",
+    "mkdirp": "~0.3.5"
+  },
+  "devDependencies": {
+    "grunt-coffeelint": "~0.0",
+    "grunt-simple-mocha": "~0.4",
+    "grunt-contrib-clean": "~0.4"
+  },
+  "engines": {
+    "node": ">=0.8",
+    "npm": ">=1.2"
+  }
 }

--- a/tasks/coffeeCoverage.coffee
+++ b/tasks/coffeeCoverage.coffee
@@ -1,12 +1,27 @@
-coffeeCoverage = require "coffee-coverage"
-
+cc = require 'coffee-coverage'
+fs = require 'fs'
+mkdirp = require 'mkdirp'
+path = require 'path'
 
 module.exports = (grunt) ->
-    grunt.registerMultiTask "coffeeCoverage", ->
+    grunt.registerMultiTask 'coffeeCoverage', ->
+        instrumentor = new cc.CoverageInstrumentor
         options = @options()
-        instrumentor = new coffeeCoverage.CoverageInstrumentor
 
-        @files.forEach (files) ->
-            files.src.forEach (file) ->
-                result = instrumentor.instrument file, files.dest, options
-                grunt.log.writeln "Annotated #{result.lines} lines."
+        instrument = =>
+            for files in @files
+                for file in files.src
+                    result = instrumentor.instrument file, files.dest, options
+                    grunt.log.writeln "Annotated #{result.lines} lines."
+
+        if options.initFile?
+            done = @async()
+            initPath = path.dirname options.initFile
+            mkdirp initPath, (err) =>
+                grunt.fail.warn err if err?
+                options.initFileStream = fs.createWriteStream options.initFile
+                options.initFileStream.on 'open', =>
+                    instrument()
+                    options.initFileStream.end()
+                    done()
+        else instrument()

--- a/test/coffeeCoverage.coffee
+++ b/test/coffeeCoverage.coffee
@@ -1,13 +1,15 @@
-assert = require "assert"
-fs = require "fs"
+assert = require 'assert'
+fs = require 'fs'
 
-
-describe "Task coffeeCoverage", ->
-    it "should generage annotated javascript files", (callback) ->
+describe 'Task coffeeCoverage', ->
+    it 'should instrument coffeeCoverage.coffee', (done) ->
         file = "#{__dirname}/../tasks-cov/coffeeCoverage.js"
-
-        fs.readFile file, "utf-8", (err, data) ->
-            return callback err if err
-
+        fs.readFile file, 'utf-8', (err, data) ->
+            return done err if err
             assert.ok data.indexOf('_$jscoverage["coffeeCoverage.coffee"]') >= 0
-            callback()
+            done()
+    it 'should generate an init file', (done) ->
+        file = "#{__dirname}/../tasks-cov/init.js"
+        fs.stat file, (err, stats) ->
+            assert.ok stats.isFile()
+            done()


### PR DESCRIPTION
Added support for creating initfiles used by mocha as described
[here](https://github.com/benbria/coffee-coverage#using-with-mocha-and-nodejs).

Initfile creation is turned on with the `initFile` option.

<!---
@huboard:{"milestone_order":1.0}
-->
